### PR TITLE
kobject: handle large incoming events

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -32,27 +32,60 @@ type sysConn struct {
 	c *netlink.Conn
 }
 
-func (sc *sysConn) Read(b []byte) (int, error) {
+func (sc *sysConn) TryRead(b []byte) (int, bool, error) {
 	raw, err := sc.c.SyscallConn()
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
-	var n int
-	doErr := raw.Read(func(fd uintptr) bool {
-		n, err = unix.Read(int(fd), b)
+	var (
+		n      int
+		done   bool
+		outErr error
+	)
+
+	// Deals with any errors to raw.Read, populating outErr for the caller if
+	// necessary, and handling the appropriate runtime network poller integration
+	// logic.
+	handle := func(err error) bool {
+		eagain := err == unix.EAGAIN
+		if !eagain {
+			// Only report non-EAGAIN errors to the caller.
+			outErr = err
+		}
 
 		// When the socket is in non-blocking mode, we might see
 		// EAGAIN and end up here. In that case, return false to
 		// let the poller wait for readiness. See the source code
 		// for internal/poll.FD.RawRead for more details.
-		return err != unix.EAGAIN
-	})
-	if doErr != nil {
-		return 0, doErr
+		return !eagain
 	}
 
-	return n, err
+	doErr := raw.Read(func(fd uintptr) bool {
+		// How many bytes are available from the socket?
+		n, _, _, _, err = unix.Recvmsg(int(fd), b, nil, unix.MSG_PEEK)
+		if err != nil {
+			return handle(err)
+		}
+
+		if len(b) < n {
+			// The buffer isn't large enough to be filled in one call to Read.
+			// Inform the poller that we're immediately ready for more I/O, but
+			// also inform the caller that TryRead didn't complete.
+			return true
+		}
+
+		// The buffer is large enough to be filled in one call to Read, perform
+		// the Read and inform the caller it completed as well.
+		done = true
+		n, err = unix.Read(int(fd), b)
+		return handle(err)
+	})
+	if doErr != nil {
+		return 0, false, doErr
+	}
+
+	return n, done, outErr
 }
 
 func (sc *sysConn) Close() error                  { return sc.c.Close() }

--- a/client_test.go
+++ b/client_test.go
@@ -2,28 +2,43 @@ package kobject
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestClientReceive(t *testing.T) {
+	// A byte slice large enough that any additional data will trigger multiple
+	// calls to tryReadCloser.TryRead.
+	page := bytes.Repeat([]byte{'f'}, os.Getpagesize())
+
 	tests := []struct {
-		name string
-		b    []byte
-		e    *Event
+		name  string
+		b     []byte
+		calls int
+		e     *Event
 	}{
 		{
-			name: "empty",
+			name:  "empty",
+			calls: 1,
 		},
 		{
-			name: "header",
-			b:    []byte("add@/devices/test"),
+			name:  "header",
+			b:     []byte("add@/devices/test"),
+			calls: 1,
 		},
 		{
-			name: "no values",
-			b:    []byte("add@/devices/test\x00ACTION=add\x00DEVPATH=/devices/test\x00SUBSYSTEM=test\x00SEQNUM=1"),
+			name: "exactly one page",
+			// Verify we behave as expected and read once, even if our buffer
+			// is entirely full.
+			calls: 1,
+			b:     page,
+		},
+		{
+			name:  "no values",
+			b:     []byte("add@/devices/test\x00ACTION=add\x00DEVPATH=/devices/test\x00SUBSYSTEM=test\x00SEQNUM=1"),
+			calls: 1,
 			e: &Event{
 				Action:     Add,
 				DevicePath: "/devices/test",
@@ -33,8 +48,9 @@ func TestClientReceive(t *testing.T) {
 			},
 		},
 		{
-			name: "USB device",
-			b:    []byte("add@/devices/pci0000:00/0000:00:14.0/usb3/3-2/3-2:1.0/0003:046D:C52B.0026\x00ACTION=add\x00DEVPATH=/devices/pci0000:00/0000:00:14.0/usb3/3-2/3-2:1.0/0003:046D:C52B.0026\x00SUBSYSTEM=hid\x00SEQNUM=4618\x00HID_UNIQ=\x00MODALIAS=hid:b0003g0000v0000046Dp0000C52B\x00HID_ID=0003:0000046D:0000C52B\x00HID_NAME=Logitech USB Receiver\x00HID_PHYS=usb-0000:00:14.0-2/input0"),
+			name:  "USB device",
+			b:     []byte("add@/devices/pci0000:00/0000:00:14.0/usb3/3-2/3-2:1.0/0003:046D:C52B.0026\x00ACTION=add\x00DEVPATH=/devices/pci0000:00/0000:00:14.0/usb3/3-2/3-2:1.0/0003:046D:C52B.0026\x00SUBSYSTEM=hid\x00SEQNUM=4618\x00HID_UNIQ=\x00MODALIAS=hid:b0003g0000v0000046Dp0000C52B\x00HID_ID=0003:0000046D:0000C52B\x00HID_NAME=Logitech USB Receiver\x00HID_PHYS=usb-0000:00:14.0-2/input0"),
+			calls: 1,
 			e: &Event{
 				Action:     Add,
 				DevicePath: "/devices/pci0000:00/0000:00:14.0/usb3/3-2/3-2:1.0/0003:046D:C52B.0026",
@@ -50,8 +66,9 @@ func TestClientReceive(t *testing.T) {
 			},
 		},
 		{
-			name: "TAP interface",
-			b:    []byte("remove@/devices/virtual/net/tap0\x00ACTION=remove\x00DEVPATH=/devices/virtual/net/tap0\x00SUBSYSTEM=net\x00SEQNUM=4636\x00INTERFACE=tap0\x00IFINDEX=28"),
+			name:  "TAP interface",
+			b:     []byte("remove@/devices/virtual/net/tap0\x00ACTION=remove\x00DEVPATH=/devices/virtual/net/tap0\x00SUBSYSTEM=net\x00SEQNUM=4636\x00INTERFACE=tap0\x00IFINDEX=28"),
+			calls: 1,
 			e: &Event{
 				Action:     Remove,
 				DevicePath: "/devices/virtual/net/tap0",
@@ -63,11 +80,32 @@ func TestClientReceive(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "large event",
+			b: append(
+				[]byte("remove@/devices/virtual/net/tap0\x00ACTION=remove\x00DEVPATH=/devices/virtual/net/tap0\x00SUBSYSTEM=net\x00SEQNUM=4636\x00INTERFACE=tap0\x00IFINDEX=28\x00ARBITRARY="),
+				// Ensure this message is too large to fit in one page of memory,
+				// triggering multiple TryRead calls.
+				append(page, 0x00)...,
+			),
+			calls: 2,
+			e: &Event{
+				Action:     Remove,
+				DevicePath: "/devices/virtual/net/tap0",
+				Subsystem:  "net",
+				Sequence:   4636,
+				Values: map[string]string{
+					"IFINDEX":   "28",
+					"INTERFACE": "tap0",
+					"ARBITRARY": string(page),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := testClient(t, tt.b)
+			c, done := testClient(t, tt.b)
 			defer c.Close()
 
 			e, err := c.Receive()
@@ -79,6 +117,13 @@ func TestClientReceive(t *testing.T) {
 				t.Fatal("expected an error, but none occurred")
 			}
 
+			// Check the number of calls to TryRead.
+			calls := done()
+			if diff := cmp.Diff(tt.calls, calls); diff != "" {
+				t.Fatalf("unexpected number of TryRead calls (-want +got):\n%s", diff)
+			}
+
+			// Check the actual Event produced, if any.
 			if diff := cmp.Diff(tt.e, e); diff != "" {
 				t.Fatalf("unexpected event (-want +got):\n%s", diff)
 			}
@@ -86,13 +131,45 @@ func TestClientReceive(t *testing.T) {
 	}
 }
 
-func testClient(t *testing.T, b []byte) *Client {
+func testClient(t *testing.T, b []byte) (*Client, func() int) {
 	t.Helper()
 
-	c, err := newClient(ioutil.NopCloser(bytes.NewReader(b)))
+	rc := &testTryReadCloser{
+		br: bytes.NewReader(b),
+	}
+
+	c, err := newClient(rc)
 	if err != nil {
 		t.Fatalf("failed to create test client: %v", err)
 	}
 
-	return c
+	return c, func() int {
+		if err := c.Close(); err != nil {
+			panicf("failed to close: %v", err)
+		}
+
+		// Return the number of times TryRead was called upon completion.
+		return rc.calls
+	}
 }
+
+type testTryReadCloser struct {
+	br    *bytes.Reader
+	calls int
+}
+
+func (rc *testTryReadCloser) TryRead(b []byte) (int, bool, error) {
+	rc.calls++
+
+	// Is b large enough to fit the contents of the bytes.Reader in one call?
+	if len(b) < rc.br.Len() {
+		// No, indicate the caller should try again.
+		return 0, false, nil
+	}
+
+	// Yes, proceed with Read.
+	n, err := rc.br.Read(b)
+	return n, true, err
+}
+
+func (*testTryReadCloser) Close() error { return nil }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/google/go-cmp v0.2.0
-	github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c
-	golang.org/x/sys v0.0.0-20190312061237-fead79001313
+	github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
+	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,15 @@
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c h1:qYXI+3AN4zBWsTF5drEu1akWPu2juaXPs58tZ4/GaCg=
-github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225 h1:CxV4h424xakl+HjTCCwbXmDK8Qu/w+rRl2+cw1HDZyM=
+github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 h1:1Fzlr8kkDLQwqMP8GxrhptBLqZG/EDpiATneiZHY998=
+golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This change ensures that events that are larger than 2048 bytes can be handled properly. Although there aren't any solid integration tests in place at the moment, I was able to verify this locally by shrinking the buffer to 128 bytes initial size and then adding and removing dummy network interfaces.

/cc @andrewrynhard