### PR TITLE
kobject: re-use shared buffer, make safe for concurrent use

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -68,7 +68,7 @@ func (sc *sysConn) TryRead(b []byte) (int, bool, error) {
 			return handle(err)
 		}
 
-		if len(b) < n {
+		if len(b) <= n {
 			// The buffer isn't large enough to be filled in one call to Read.
 			// Inform the poller that we're immediately ready for more I/O, but
 			// also inform the caller that TryRead didn't complete.


### PR DESCRIPTION
I think there were a couple of subtle things wrong in the last patch, but this appears to work well on my machine. Memory is now allocated only as needed and shared in the Client.

I was even able to shrink the buffer down to 4 bytes and verify that it grows enough to process entire large events on my system.

/cc @andrewrynhard