### PR TITLE
feat: add support for setting read buffer size

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package kobject
 
@@ -90,3 +91,4 @@ func (sc *sysConn) TryRead(b []byte) (int, bool, error) {
 
 func (sc *sysConn) Close() error                  { return sc.c.Close() }
 func (sc *sysConn) SetDeadline(t time.Time) error { return sc.c.SetDeadline(t) }
+func (sc *sysConn) SetReadBuffer(bytes int) error { return sc.c.SetReadBuffer(bytes) }

--- a/cmd/kobject/main.go
+++ b/cmd/kobject/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	var (
 		tFlag = flag.Duration("t", 0*time.Second, "the amount of time to wait between events before timing out (default: forever)")
+		rFlag = flag.Int("r", 0, "the size of the read buffer for kobject events (0 for default size)")
 	)
 	flag.Parse()
 
@@ -22,6 +23,12 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	defer c.Close()
+
+	if *rFlag != 0 {
+		if err = c.SetReadBuffer(*rFlag); err != nil {
+			log.Fatalf("failed to set read buffer: %v", err)
+		}
+	}
 
 	for {
 		if *tFlag > 0 {


### PR DESCRIPTION
Without it, under high even rate from the kernel (e.g. OS boot), the call will fail with ENOBUFS, and the client would lose the event stream.