### PR TITLE
feat(conn): expose socket option and read buffer size options

### DIFF
--- a/client.go
+++ b/client.go
@@ -117,7 +117,7 @@ func (c *Client) SetReadBuffer(bytes int) error {
 func (c *Client) SetOption(option netlink.ConnOption, enable bool) error {
 	conn, ok := c.rc.(conn)
 	if !ok {
-		panicf("kobject: BUG: connection options not supported on internal conn type: %#v", c.rc)
+		panicf("kobject: BUG: socket options not supported on internal conn type: %#v", c.rc)
 	}
 
 	return conn.SetOption(option, enable)

--- a/client_linux.go
+++ b/client_linux.go
@@ -90,3 +90,7 @@ func (sc *sysConn) TryRead(b []byte) (int, bool, error) {
 
 func (sc *sysConn) Close() error                  { return sc.c.Close() }
 func (sc *sysConn) SetDeadline(t time.Time) error { return sc.c.SetDeadline(t) }
+func (sc *sysConn) SetReadBuffer(bytes int) error { return sc.c.SetReadBuffer(bytes) }
+func (sc *sysConn) SetOption(option netlink.ConnOption, enable bool) error {
+	return sc.c.SetOption(option, enable)
+}


### PR DESCRIPTION
Similar in spirit to #5, except it also exposes the `SetOption()` method for the ability to set the `netlink.NoENOBUFS` option on the netlink socket, in which case the socket won't be closed when no buffer space is available. In this case, missed uevents can be detected by observing a gap in the sequence numbers (`SEQNUM`) of uevents.