### PR TITLE
fix: use 64 bits for representing the sequence number of uevents

### DIFF
--- a/event.go
+++ b/event.go
@@ -26,7 +26,7 @@ type Event struct {
 	Action     Action
 	DevicePath string
 	Subsystem  string
-	Sequence   int
+	Sequence   uint64
 
 	// Values contains arbitrary key/value pairs which are not present in
 	// all Events.
@@ -54,7 +54,7 @@ func parseEvent(fields [][]byte) (*Event, error) {
 		case "SUBSYSTEM":
 			e.Subsystem = kv[1]
 		case "SEQNUM":
-			v, err := strconv.Atoi(kv[1])
+			v, err := strconv.ParseUint(kv[1], 10, 64)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Kernel uses a [64-bit `atomic64_t`](https://elixir.bootlin.com/linux/v6.12.6/source/lib/kobject_uevent.c#L33) type for representing the auto-incremented uevent sequence number. Although rare, this could in theory allow the possibility of an overflow on 32-bit systems.